### PR TITLE
add credits menu and refactor screen menus onto a shared base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,54 @@
 # RetroNome
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+A Game Boy Color-styled metronome web app built with vanilla JavaScript.
 
-## Table of Contents
+## About
 
-- [Description](#description)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [License](#license)
-  - [Contributing](#how-to-contribute)
-  - [Testing](#tests)
-  - [Questions](#questions)
+RetroNome is a fully functional metronome wrapped in a pixel-perfect Game Boy Color interface. The entire UI -- screen, D-pad, A/B buttons, speaker grille -- is rendered in CSS to match the look and feel of the original handheld. It runs as a progressive web app and can be installed on mobile devices for a native-like experience.
 
-## Description
+## Screenshots
 
-RetroNome is a metronome with a UI that resembles a handheld game console for a nostalgic and fun practice experience. 
+<!-- TODO: Add before/after screenshots -->
 
-## Installation
+## Built With
 
-Simply enter the link into your browser!
+- [Tone.js](https://tonejs.github.io/) -- Web audio framework powering the metronome's oscillator-based click engine and subdivision timing
+- [NES.css](https://nostalgic-css.github.io/NES.css/) -- NES-style CSS framework
+- [Vite](https://vitejs.dev/) -- Build tool and development server
+- [Google Fonts](https://fonts.google.com/) -- Press Start 2P (primary pixel font), VT323, Sedgwick Ave
 
-## Usage 
+## Features
 
-This application is intended for musicians to track their growth. Most metronomes do not have a specified notes section for musicians to keep track of what they practiced, and what they intend to practice next.
+- Tempo control with tap and hold-to-repeat via the D-pad
+- Adjustable time signature (1-12 beats)
+- Per-beat accent and mute toggling
+- Four oscillator waveforms (sine, sawtooth, triangle, pulse)
+- Subdivision options (quarter, eighth, sixteenth, triplet)
+- Color customization for the body, play button, and stop button (persisted to localStorage)
+- Installable as a progressive web app
+- Fullscreen mode on mobile browsers
 
+## Getting Started
 
-## Questions
+```
+npm install
+npm run dev
+```
 
-* Github: https://github.com/undefined
-* Email: JeffMoroMusic@gmail.com
+To create a production build:
 
+```
+npm run build
+npm run preview
+```
 
+## License
+
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).
+
+## Contact
+
+- GitHub: [Reptartheman](https://github.com/Reptartheman)
+- Email: JeffMoroMusic@gmail.com

--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -19,6 +19,7 @@ import { tempoDisplay } from './ui/TempoDisplay.js';
 import { controls } from './ui/Controls.js';
 import { colorMenu } from './ui/ColorMenu.js';
 import { toneMenu } from './ui/ToneMenu.js';
+import { creditsMenu } from './ui/CreditsMenu.js';
 
 /**
  * Request fullscreen on first touch for in-browser Android users.
@@ -49,6 +50,7 @@ function initApp() {
   controls.init();
   colorMenu.init();
   toneMenu.init();
+  creditsMenu.init();
   initFullscreen();
 }
 

--- a/assets/scripts/ui/BeatVisualizer.js
+++ b/assets/scripts/ui/BeatVisualizer.js
@@ -121,15 +121,15 @@ class BeatVisualizer {
   }
 
   /**
-   * Bind accent tap to a beat block
+   * Bind accent tap to a beat block.
+   * `touch-action: manipulation` (set globally in CSS) makes click fire
+   * immediately on tap, so a separate touchend listener is unnecessary.
    */
   _bindAccentTap(block, index) {
-    const handler = (e) => {
+    block.addEventListener('click', (e) => {
       e.preventDefault();
       metronomeState.toggleAccent(index);
-    };
-    block.addEventListener('click', handler);
-    block.addEventListener('touchend', handler);
+    });
   }
 
   /**

--- a/assets/scripts/ui/ColorMenu.js
+++ b/assets/scripts/ui/ColorMenu.js
@@ -3,6 +3,8 @@
  * Toggled by the SELECT button
  */
 
+import { ScreenMenu } from './ScreenMenu.js';
+
 const COLORS = [
   { name: 'sand-dune', value: '#e8dcc2' },
   { name: 'blue-energy', value: '#4a90e2' },
@@ -18,65 +20,17 @@ const TARGETS = [
   { key: 'stop', label: 'STOP' },
 ];
 
-class ColorMenu {
-  constructor() {
-    this._isOpen = false;
-    this._menuEl = null;
-    this._screenInner = null;
-    this._selected = {
-      gameboy: null,
-      play: null,
-      stop: null,
-    };
-  }
+const STORAGE_KEY = 'retronome-colors';
 
-  get isOpen() {
-    return this._isOpen;
+class ColorMenu extends ScreenMenu {
+  constructor() {
+    super('color-menu');
+    this._selected = { gameboy: null, play: null, stop: null };
   }
 
   init() {
-    this._screenInner = document.querySelector('.screen-inner');
+    super.init();
     this._loadFromStorage();
-  }
-
-  toggle() {
-    if (this._isOpen) {
-      this.close();
-    } else {
-      this.open();
-    }
-  }
-
-  open() {
-    if (this._isOpen) return;
-    this._isOpen = true;
-
-    // Hide existing screen content
-    Array.from(this._screenInner.children).forEach(child => {
-      if (!child.classList.contains('color-menu')) {
-        child.style.display = 'none';
-      }
-    });
-
-    // Create and append menu
-    this._menuEl = this._createMenu();
-    this._screenInner.appendChild(this._menuEl);
-  }
-
-  close() {
-    if (!this._isOpen) return;
-    this._isOpen = false;
-
-    // Remove menu
-    if (this._menuEl) {
-      this._menuEl.remove();
-      this._menuEl = null;
-    }
-
-    // Restore existing screen content
-    Array.from(this._screenInner.children).forEach(child => {
-      child.style.display = '';
-    });
   }
 
   _createMenu() {
@@ -89,53 +43,46 @@ class ColorMenu {
     menu.appendChild(title);
 
     TARGETS.forEach(target => {
-      const group = document.createElement('div');
-      group.className = 'color-menu-group';
-
-      const label = document.createElement('span');
-      label.className = 'color-menu-label';
-      label.textContent = target.label;
-      group.appendChild(label);
-
-      const swatches = document.createElement('div');
-      swatches.className = 'color-swatches';
-
-      COLORS.forEach((color, index) => {
-        const swatch = document.createElement('button');
-        swatch.className = 'color-swatch';
-        swatch.style.backgroundColor = color.value;
-        swatch.setAttribute('aria-label', `${target.label} ${color.name}`);
-
-        // Mark as selected if this is the current choice
-        if (this._selected[target.key] === index) {
-          swatch.classList.add('selected');
-        }
-
-        swatch.addEventListener('click', (e) => {
-          e.preventDefault();
-          this._applyColor(target.key, index);
-
-          // Update selected states within this row
-          swatches.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
-          swatch.classList.add('selected');
-        });
-
-        swatch.addEventListener('touchend', (e) => {
-          e.preventDefault();
-          this._applyColor(target.key, index);
-
-          swatches.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
-          swatch.classList.add('selected');
-        });
-
-        swatches.appendChild(swatch);
-      });
-
-      group.appendChild(swatches);
-      menu.appendChild(group);
+      menu.appendChild(this._createTargetGroup(target));
     });
 
     return menu;
+  }
+
+  _createTargetGroup(target) {
+    const group = document.createElement('div');
+    group.className = 'color-menu-group';
+
+    const label = document.createElement('span');
+    label.className = 'color-menu-label';
+    label.textContent = target.label;
+    group.appendChild(label);
+
+    const swatches = document.createElement('div');
+    swatches.className = 'color-swatches';
+
+    COLORS.forEach((color, index) => {
+      const swatch = document.createElement('button');
+      swatch.className = 'color-swatch';
+      swatch.style.backgroundColor = color.value;
+      swatch.setAttribute('aria-label', `${target.label} ${color.name}`);
+
+      if (this._selected[target.key] === index) {
+        swatch.classList.add('selected');
+      }
+
+      swatch.addEventListener('click', (e) => {
+        e.preventDefault();
+        this._applyColor(target.key, index);
+        swatches.querySelectorAll('.color-swatch').forEach(s => s.classList.remove('selected'));
+        swatch.classList.add('selected');
+      });
+
+      swatches.appendChild(swatch);
+    });
+
+    group.appendChild(swatches);
+    return group;
   }
 
   _applyColor(target, colorIndex) {
@@ -144,15 +91,9 @@ class ColorMenu {
     this._saveToStorage();
 
     switch (target) {
-      case 'gameboy':
-        this._applyGameboyColor(color);
-        break;
-      case 'play':
-        this._applyPlayColor(color);
-        break;
-      case 'stop':
-        this._applyStopColor(color);
-        break;
+      case 'gameboy': this._applyGameboyColor(color); break;
+      case 'play':    this._applyPlayColor(color); break;
+      case 'stop':    this._applyStopColor(color); break;
     }
   }
 
@@ -210,13 +151,13 @@ class ColorMenu {
 
   _saveToStorage() {
     try {
-      localStorage.setItem('retronome-colors', JSON.stringify(this._selected));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this._selected));
     } catch (_) { /* storage full or unavailable */ }
   }
 
   _loadFromStorage() {
     try {
-      const saved = JSON.parse(localStorage.getItem('retronome-colors'));
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
       if (!saved) return;
       for (const key of Object.keys(this._selected)) {
         if (typeof saved[key] === 'number' && saved[key] >= 0 && saved[key] < COLORS.length) {

--- a/assets/scripts/ui/Controls.js
+++ b/assets/scripts/ui/Controls.js
@@ -1,146 +1,98 @@
 /**
  * Controls - Handles all user input controls
  * Bridges user interactions with state and audio engine
+ *
+ * Tap handling: all interactive elements have `touch-action: manipulation` set
+ * in CSS, so `click` fires immediately on touch with no 300ms delay. We do not
+ * need separate `touchend` listeners (except for hold-to-repeat, where we
+ * track touchstart/touchend explicitly).
  */
 
 import { metronomeState } from '../state/MetronomeState.js';
 import { audioEngine } from '../audio/AudioEngine.js';
 import { colorMenu } from './ColorMenu.js';
 import { toneMenu } from './ToneMenu.js';
+import { creditsMenu } from './CreditsMenu.js';
+
+const HOLD_REPEAT_MS = 150;
 
 class Controls {
   constructor() {
     this._elements = {};
     this._holdInterval = null;
-    this._holdDelay = 150; // ms between repeats when holding
   }
 
-  /**
-   * Initialize all controls
-   */
   init() {
     this._cacheElements();
     this._bindEvents();
     this._subscribeToState();
   }
 
-  /**
-   * Cache DOM elements
-   */
   _cacheElements() {
     this._elements = {
-      // Start/Stop buttons (A and B)
       btnStart: document.getElementById('btnStart'),
       btnStop: document.getElementById('btnStop'),
-      
-      // D-Pad buttons
       dpadUp: document.getElementById('dpadUp'),
       dpadDown: document.getElementById('dpadDown'),
       dpadLeft: document.getElementById('dpadLeft'),
       dpadRight: document.getElementById('dpadRight'),
-      
-      // Display elements
       beatCountDisplay: document.querySelector('.beat-count'),
-
-      // Menu buttons
       selectBtn: document.getElementById('selectBtn'),
       startBtn: document.getElementById('startBtn'),
+      brandText: document.querySelector('.brand-color'),
     };
   }
 
-  /**
-   * Bind event listeners
-   */
   _bindEvents() {
-    // A Button (Start)
-    if (this._elements.btnStart) {
-      const handleStart = async (e) => {
-        e.preventDefault();
-        await this._handleStart();
-      };
-      this._elements.btnStart.addEventListener('click', handleStart);
-      this._elements.btnStart.addEventListener('touchend', handleStart);
-    }
+    const e = this._elements;
 
-    // B Button (Stop)
-    if (this._elements.btnStop) {
-      const handleStop = (e) => {
-        e.preventDefault();
-        this._handleStop();
-      };
-      this._elements.btnStop.addEventListener('click', handleStop);
-      this._elements.btnStop.addEventListener('touchend', handleStop);
-    }
+    this._onClick(e.btnStart, () => this._handleStart());
+    this._onClick(e.btnStop, () => this._handleStop());
 
-    // D-Pad Up - Increase tempo (with hold support)
-    if (this._elements.dpadUp) {
-      this._bindHoldAction(this._elements.dpadUp, () => {
-        metronomeState.setBpm(metronomeState.bpm + 1);
-      });
-    }
+    this._bindHoldAction(e.dpadUp,   () => metronomeState.setBpm(metronomeState.bpm + 1));
+    this._bindHoldAction(e.dpadDown, () => metronomeState.setBpm(metronomeState.bpm - 1));
 
-    // D-Pad Down - Decrease tempo (with hold support)
-    if (this._elements.dpadDown) {
-      this._bindHoldAction(this._elements.dpadDown, () => {
-        metronomeState.setBpm(metronomeState.bpm - 1);
-      });
-    }
+    this._onClick(e.dpadRight, () => metronomeState.setTimeSignature(metronomeState.timeSignature + 1));
+    this._onClick(e.dpadLeft,  () => metronomeState.setTimeSignature(metronomeState.timeSignature - 1));
 
-    // D-Pad Right - Add beat
-    if (this._elements.dpadRight) {
-      const addBeat = (e) => {
-        e.preventDefault();
-        metronomeState.setTimeSignature(metronomeState.timeSignature + 1);
-      };
-      this._elements.dpadRight.addEventListener('click', addBeat);
-      this._elements.dpadRight.addEventListener('touchend', addBeat);
-    }
+    // Each menu toggle closes the others (mutual exclusion).
+    const menus = [colorMenu, toneMenu, creditsMenu];
+    this._bindMenuToggle(e.selectBtn, colorMenu, menus);
+    this._bindMenuToggle(e.startBtn,  toneMenu, menus);
+    this._bindMenuToggle(e.brandText, creditsMenu, menus);
+  }
 
-    // D-Pad Left - Remove beat
-    if (this._elements.dpadLeft) {
-      const removeBeat = (e) => {
-        e.preventDefault();
-        metronomeState.setTimeSignature(metronomeState.timeSignature - 1);
-      };
-      this._elements.dpadLeft.addEventListener('click', removeBeat);
-      this._elements.dpadLeft.addEventListener('touchend', removeBeat);
-    }
+  _onClick(element, handler) {
+    if (!element) return;
+    element.addEventListener('click', async (event) => {
+      event.preventDefault();
+      await handler();
+    });
+  }
 
-    // COLORS - Toggle color menu (close tone menu if open)
-    if (this._elements.selectBtn) {
-      const toggleColors = (e) => {
-        e.preventDefault();
-        if (toneMenu.isOpen) toneMenu.close();
-        colorMenu.toggle();
-      };
-      this._elements.selectBtn.addEventListener('click', toggleColors);
-      this._elements.selectBtn.addEventListener('touchend', toggleColors);
-    }
-
-    // TONES - Toggle tone menu (close color menu if open)
-    if (this._elements.startBtn) {
-      const toggleTones = (e) => {
-        e.preventDefault();
-        if (colorMenu.isOpen) colorMenu.close();
-        toneMenu.toggle();
-      };
-      this._elements.startBtn.addEventListener('click', toggleTones);
-      this._elements.startBtn.addEventListener('touchend', toggleTones);
-    }
+  _bindMenuToggle(element, target, allMenus) {
+    this._onClick(element, () => {
+      for (const m of allMenus) {
+        if (m !== target && m.isOpen) m.close();
+      }
+      target.toggle();
+    });
   }
 
   /**
-   * Bind hold action for continuous input (tap and hold)
+   * Bind hold action for continuous input (tap and hold).
+   * Uses pointerdown/up/cancel to handle mouse and touch uniformly.
    */
   _bindHoldAction(element, action) {
+    if (!element) return;
     let isHolding = false;
 
     const startHold = (e) => {
       e.preventDefault();
       if (isHolding) return;
       isHolding = true;
-      action(); // Immediate action
-      this._holdInterval = setInterval(action, this._holdDelay);
+      action();
+      this._holdInterval = setInterval(action, HOLD_REPEAT_MS);
     };
 
     const endHold = () => {
@@ -151,29 +103,21 @@ class Controls {
       }
     };
 
-    // Mouse events
     element.addEventListener('mousedown', startHold);
     element.addEventListener('mouseup', endHold);
     element.addEventListener('mouseleave', endHold);
-
-    // Touch events
     element.addEventListener('touchstart', startHold, { passive: false });
     element.addEventListener('touchend', endHold);
     element.addEventListener('touchcancel', endHold);
   }
 
-  /**
-   * Subscribe to state changes for UI updates
-   */
   _subscribeToState() {
-    // Update beat count display
     metronomeState.subscribe('timeSignature', (timeSignature) => {
       if (this._elements.beatCountDisplay) {
         this._elements.beatCountDisplay.textContent = timeSignature;
       }
     });
 
-    // Update button states based on playing state
     metronomeState.subscribe('isPlaying', (isPlaying) => {
       if (this._elements.btnStart) {
         this._elements.btnStart.style.opacity = isPlaying ? '0.5' : '1';
@@ -184,24 +128,16 @@ class Controls {
     });
   }
 
-  /**
-   * Handle start
-   */
   async _handleStart() {
-    if (metronomeState.isPlaying) return; // Already playing
-    
-    // Initialize audio engine on first interaction (required by browsers)
+    if (metronomeState.isPlaying) return;
     if (!audioEngine.isInitialized) {
       await audioEngine.init();
     }
     audioEngine.start();
   }
 
-  /**
-   * Handle stop
-   */
   _handleStop() {
-    if (!metronomeState.isPlaying) return; // Already stopped
+    if (!metronomeState.isPlaying) return;
     audioEngine.stop();
   }
 }

--- a/assets/scripts/ui/CreditsMenu.js
+++ b/assets/scripts/ui/CreditsMenu.js
@@ -1,0 +1,52 @@
+/**
+ * CreditsMenu - Shows credits/links on the screen
+ * Toggled by tapping the "RetroNome v2" brand text
+ */
+
+import { ScreenMenu } from './ScreenMenu.js';
+
+const LINKS = [
+  { label: 'GITHUB', url: '#' },
+  { label: 'COFFEE', url: '#' },
+  { label: 'WEBSITE', url: '#' },
+];
+
+class CreditsMenu extends ScreenMenu {
+  constructor() {
+    super('credits-menu');
+  }
+
+  _createMenu() {
+    const menu = document.createElement('div');
+    menu.className = 'credits-menu';
+
+    const title = document.createElement('div');
+    title.className = 'credits-title';
+    title.textContent = 'CREDITS';
+    menu.appendChild(title);
+
+    const byline = document.createElement('div');
+    byline.className = 'credits-byline';
+    byline.textContent = 'by Jeff Moro';
+    menu.appendChild(byline);
+
+    const linksContainer = document.createElement('div');
+    linksContainer.className = 'credits-links';
+
+    LINKS.forEach(({ label, url }) => {
+      const link = document.createElement('a');
+      link.className = 'credits-link';
+      link.href = url;
+      link.target = '_blank';
+      link.rel = 'noopener';
+      link.textContent = label;
+      linksContainer.appendChild(link);
+    });
+
+    menu.appendChild(linksContainer);
+    return menu;
+  }
+}
+
+// Export singleton instance
+export const creditsMenu = new CreditsMenu();

--- a/assets/scripts/ui/ScreenMenu.js
+++ b/assets/scripts/ui/ScreenMenu.js
@@ -1,0 +1,69 @@
+/**
+ * ScreenMenu - Base class for the on-screen menus (colors, tones, credits)
+ *
+ * Subclasses implement _createMenu() to build the menu DOM. The base handles
+ * mounting/unmounting into .screen-inner and hiding sibling content while open.
+ */
+
+export class ScreenMenu {
+  constructor(menuClass) {
+    this._menuClass = menuClass;
+    this._isOpen = false;
+    this._menuEl = null;
+    this._screenInner = null;
+  }
+
+  get isOpen() {
+    return this._isOpen;
+  }
+
+  init() {
+    this._screenInner = document.querySelector('.screen-inner');
+  }
+
+  toggle() {
+    if (this._isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open() {
+    if (this._isOpen) return;
+    this._isOpen = true;
+
+    // Hide existing screen content
+    for (const child of this._screenInner.children) {
+      if (!child.classList.contains(this._menuClass)) {
+        child.style.display = 'none';
+      }
+    }
+
+    this._menuEl = this._createMenu();
+    this._screenInner.appendChild(this._menuEl);
+  }
+
+  close() {
+    if (!this._isOpen) return;
+    this._isOpen = false;
+
+    if (this._menuEl) {
+      this._menuEl.remove();
+      this._menuEl = null;
+    }
+
+    // Restore existing screen content
+    for (const child of this._screenInner.children) {
+      child.style.display = '';
+    }
+  }
+
+  /**
+   * Subclasses implement: build and return the menu DOM element.
+   * The element's classList must include this._menuClass.
+   */
+  _createMenu() {
+    throw new Error('ScreenMenu subclass must implement _createMenu()');
+  }
+}

--- a/assets/scripts/ui/ToneMenu.js
+++ b/assets/scripts/ui/ToneMenu.js
@@ -1,8 +1,9 @@
 /**
- * ToneMenu - Handles the tone selection menu displayed on the screen
+ * ToneMenu - Handles the tone & subdivision menu displayed on the screen
  * Toggled by the TONES button
  */
 
+import { ScreenMenu } from './ScreenMenu.js';
 import { audioEngine } from '../audio/AudioEngine.js';
 import { metronomeState } from '../state/MetronomeState.js';
 
@@ -20,152 +21,64 @@ const SUBDIVISIONS = [
   { label: 'triplets', key: 'triplet' },
 ];
 
-class ToneMenu {
+class ToneMenu extends ScreenMenu {
   constructor() {
-    this._isOpen = false;
-    this._menuEl = null;
-    this._screenInner = null;
-    this._selectedIndex = 2; // triangle is the default
-    this._selectedSubIndex = 0; // quarter notes is the default
-  }
-
-  get isOpen() {
-    return this._isOpen;
-  }
-
-  init() {
-    this._screenInner = document.querySelector('.screen-inner');
-  }
-
-  toggle() {
-    if (this._isOpen) {
-      this.close();
-    } else {
-      this.open();
-    }
-  }
-
-  open() {
-    if (this._isOpen) return;
-    this._isOpen = true;
-
-    // Hide existing screen content
-    Array.from(this._screenInner.children).forEach(child => {
-      if (!child.classList.contains('tone-menu')) {
-        child.style.display = 'none';
-      }
-    });
-
-    this._menuEl = this._createMenu();
-    this._screenInner.appendChild(this._menuEl);
-  }
-
-  close() {
-    if (!this._isOpen) return;
-    this._isOpen = false;
-
-    if (this._menuEl) {
-      this._menuEl.remove();
-      this._menuEl = null;
-    }
-
-    // Restore existing screen content
-    Array.from(this._screenInner.children).forEach(child => {
-      child.style.display = '';
-    });
+    super('tone-menu');
+    this._selectedIndex = 2;     // triangle is the default
+    this._selectedSubIndex = 0;  // quarter notes is the default
   }
 
   _createMenu() {
     const menu = document.createElement('div');
     menu.className = 'tone-menu';
 
-    // --- Tones section ---
-    const toneTitle = document.createElement('div');
-    toneTitle.className = 'tone-menu-title';
-    toneTitle.textContent = 'TONES';
-    menu.appendChild(toneTitle);
+    menu.appendChild(this._createTitle('TONES'));
+    menu.appendChild(this._createGrid(TONES, this._selectedIndex, (item, index) => {
+      this._selectedIndex = index;
+      audioEngine.setOscillatorType(item.type);
+    }));
 
-    const toneGrid = document.createElement('div');
-    toneGrid.className = 'tone-grid';
-
-    TONES.forEach((tone, index) => {
-      const btn = document.createElement('button');
-      btn.className = 'tone-option';
-      btn.textContent = tone.label;
-
-      if (this._selectedIndex === index) {
-        btn.classList.add('selected');
-      }
-
-      btn.addEventListener('click', (e) => {
-        e.preventDefault();
-        this._selectedIndex = index;
-        audioEngine.setOscillatorType(tone.type);
-
-        toneGrid.querySelectorAll('.tone-option').forEach(b => b.classList.remove('selected'));
-        btn.classList.add('selected');
-      });
-
-      btn.addEventListener('touchend', (e) => {
-        e.preventDefault();
-        this._selectedIndex = index;
-        audioEngine.setOscillatorType(tone.type);
-
-        toneGrid.querySelectorAll('.tone-option').forEach(b => b.classList.remove('selected'));
-        btn.classList.add('selected');
-      });
-
-      toneGrid.appendChild(btn);
-    });
-
-    menu.appendChild(toneGrid);
-
-    // --- Divider ---
     const hr = document.createElement('hr');
     hr.className = 'tone-menu-divider';
     menu.appendChild(hr);
 
-    // --- Subdivisions section ---
-    const subTitle = document.createElement('div');
-    subTitle.className = 'tone-menu-title';
-    subTitle.textContent = 'SUBDIVISION';
-    menu.appendChild(subTitle);
+    menu.appendChild(this._createTitle('SUBDIVISION'));
+    menu.appendChild(this._createGrid(SUBDIVISIONS, this._selectedSubIndex, (item, index) => {
+      this._selectedSubIndex = index;
+      metronomeState.setSubdivision(item.key);
+    }));
 
-    const subGrid = document.createElement('div');
-    subGrid.className = 'tone-grid';
+    return menu;
+  }
 
-    SUBDIVISIONS.forEach((sub, index) => {
+  _createTitle(text) {
+    const title = document.createElement('div');
+    title.className = 'tone-menu-title';
+    title.textContent = text;
+    return title;
+  }
+
+  _createGrid(items, selectedIndex, onSelect) {
+    const grid = document.createElement('div');
+    grid.className = 'tone-grid';
+
+    items.forEach((item, index) => {
       const btn = document.createElement('button');
       btn.className = 'tone-option';
-      btn.textContent = sub.label;
-
-      if (this._selectedSubIndex === index) {
-        btn.classList.add('selected');
-      }
+      btn.textContent = item.label;
+      if (index === selectedIndex) btn.classList.add('selected');
 
       btn.addEventListener('click', (e) => {
         e.preventDefault();
-        this._selectedSubIndex = index;
-        metronomeState.setSubdivision(sub.key);
-
-        subGrid.querySelectorAll('.tone-option').forEach(b => b.classList.remove('selected'));
+        onSelect(item, index);
+        grid.querySelectorAll('.tone-option').forEach(b => b.classList.remove('selected'));
         btn.classList.add('selected');
       });
 
-      btn.addEventListener('touchend', (e) => {
-        e.preventDefault();
-        this._selectedSubIndex = index;
-        metronomeState.setSubdivision(sub.key);
-
-        subGrid.querySelectorAll('.tone-option').forEach(b => b.classList.remove('selected'));
-        btn.classList.add('selected');
-      });
-
-      subGrid.appendChild(btn);
+      grid.appendChild(btn);
     });
 
-    menu.appendChild(subGrid);
-    return menu;
+    return grid;
   }
 }
 

--- a/assets/styles/default.css
+++ b/assets/styles/default.css
@@ -78,13 +78,10 @@ body {
   width: 100vw;
   height: 100dvh;
   background: linear-gradient(180deg, var(--gbc-purple-light) 0%, var(--gbc-purple) 50%, var(--gbc-purple-dark) 100%);
-  border-radius: 0;
   display: flex;
   flex-direction: column;
   padding: 15px;
-  box-shadow: none;
   position: relative;
-  border: none;
   touch-action: manipulation;
 }
 
@@ -104,6 +101,20 @@ body {
   font-weight: bold;
   letter-spacing: 2px;
   color: var(--graphite);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.brand-color::after {
+  content: ' </>';
+  font-size: var(--size-10);
+  vertical-align: middle;
+  opacity: 0.6;
+}
+
+.brand-color:active {
+  opacity: 0.6;
 }
 
 /* ----------------------- SCREEN BEZEL ----------------------- */
@@ -579,6 +590,63 @@ body {
   background: var(--gbc-screen-darkest);
   color: var(--gbc-screen-bg);
   border-color: var(--gbc-screen-darkest);
+}
+
+/* ----------------------- CREDITS MENU ----------------------- */
+
+.credits-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+
+.credits-title {
+  font-family: 'Press Start 2P', cursive;
+  font-size: 12px;
+  color: var(--gbc-screen-darkest);
+  text-align: center;
+}
+
+.credits-byline {
+  font-family: 'Press Start 2P', cursive;
+  font-size: 8px;
+  color: var(--gbc-screen-dark);
+  text-align: center;
+}
+
+.credits-links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.credits-link {
+  display: block;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 9px;
+  color: var(--gbc-screen-dark);
+  background: var(--gbc-screen-light);
+  border: 2px solid var(--gbc-screen-dark);
+  border-radius: 4px;
+  padding: 10px 8px;
+  text-align: center;
+  text-decoration: none;
+  transition: all 0.1s;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.credits-link:active {
+  background: var(--gbc-screen-darkest);
+  color: var(--gbc-screen-bg);
+  border-color: var(--gbc-screen-darkest);
+  transform: scale(0.95);
 }
 
 /* ----------------------- DESKTOP STYLES ----------------------- */


### PR DESCRIPTION
Introduces a CreditsMenu (toggled by the brand text) and extracts the shared open/close/toggle/mount-into-.screen-inner plumbing from ColorMenu, ToneMenu, and CreditsMenu into a ScreenMenu base class.

Also collapses redundant click+touchend handler pairs across Controls, BeatVisualizer, ColorMenu, and ToneMenu into single click listeners -- safe because every interactive element has touch-action: manipulation in CSS, removing the click delay. Adds a menu-mutual-exclusion helper in Controls. Drops three CSS-default declarations on .gameboy. Updates README with a real description.